### PR TITLE
backprojection: simplify interp function

### DIFF
--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -12,7 +12,6 @@ using namespace std;
 using Halide::Runtime::Buffer;
 
 #define DEBUG_Q 0
-#define DEBUG_DR 0
 #define DEBUG_NORM_R0 0
 #define DEBUG_RR0 0
 #define DEBUG_NORM_RR0 0
@@ -306,9 +305,6 @@ int main(int argc, char **argv) {
 #if DEBUG_Q
     Buffer<float, 3> out_q(2, N_fft, fft_outbuf.dim(2).extent());
 #endif
-#if DEBUG_DR
-    Buffer<double, 1> out_dr(N_fft);
-#endif
 #if DEBUG_NORM_R0
     Buffer<float, 1> out_norm_r0(fft_outbuf.dim(2).extent());
 #endif
@@ -350,9 +346,6 @@ int main(int argc, char **argv) {
 #if DEBUG_Q
         out_q,
 #endif
-#if DEBUG_DR
-        out_dr,
-#endif
 #if DEBUG_NORM_R0
         out_norm_r0,
 #endif
@@ -389,10 +382,6 @@ int main(int argc, char **argv) {
                              static_cast<size_t>(out_q.dim(1).extent()),
                              static_cast<size_t>(out_q.dim(0).extent()) };
     cnpy::npy_save("sarbp_debug-q.npy", (float *)out_q.begin(), shape_q);
-#endif
-#if DEBUG_DR
-    vector<size_t> shape_dr { static_cast<size_t>(out_dr.dim(0).extent()) };
-    cnpy::npy_save("sarbp_debug-dr.npy", (double *)out_dr.begin(), shape_dr);
 #endif
 #if DEBUG_NORM_R0
     vector<size_t> shape_norm_r0 { static_cast<size_t>(out_norm_r0.dim(0).extent()) };


### PR DESCRIPTION
Improve the algorithm by using linspace parameters directly, rather than generating the full linspace array and then searching it.

Remove the now unused `Func dr`, `RDom rnfft`, and the corresponding debug scaffolding.

This improves the overall backprojection_post_fft() execution time by more than 800% on my machine.

Performance profile before:

```
backprojection_post_fft
 total time: 32023.466797 ms  samples: 30256  runs: 1  time/run: 32023.466797 ms
 average threads used: 55.263550
 heap allocations: 13  peak heap usage: 5901387604 bytes
  norm_r0:               0.000ms   (0%)    threads: 0.000  peak: 1876     num: 1         avg: 1876
  sum:                   0.000ms   (0%)    threads: 0.000  stack: 4
  rr0:                   713.942ms (2%)    threads: 1.000  peak: 2950692864 num: 1       avg: -1344274432
  norm_rr0:              533.223ms (1%)    threads: 1.000  peak: 983564288 num: 1        avg: 983564288
  sum$1:                 93.174ms  (0%)    threads: 1.000  stack: 8
  dr_i:                  682.687ms (2%)    threads: 1.000  peak: 983564288 num: 1        avg: 983564288
  linspace:              0.000ms   (0%)    threads: 0.000  peak: 8192     num: 1         avg: 8192
  in_im:                 2.136ms   (0%)    threads: 1.000  peak: 3842048  num: 1         avg: 3842048
  f1:                    2.107ms   (0%)    threads: 1.000  peak: 3842048  num: 1         avg: 3842048
  Q_imag:                85.640ms  (0%)    threads: 61.333 peak: 983564288 num: 1        avg: 983564288
  argmax$3:              6985.279ms(21%)   threads: 60.876 stack: 5
  argmax$2:              6571.048ms(20%)   threads: 61.257 stack: 5
  Q_real:                72.926ms  (0%)    threads: 61.739 peak: 983564288 num: 1        avg: 983564288
  argmax$1:              7001.736ms(21%)   threads: 60.730 stack: 5
  argmax:                6645.325ms(20%)   threads: 60.453 stack: 5
  f2:                    874.320ms (2%)    threads: 1.000  peak: 1967128576 num: 1       avg: 1967128576
  f3:                    1700.720ms(5%)    threads: 59.947 peak: 4194304  num: 1         avg: 4194304
  f4:                    56.036ms  (0%)    threads: 1.000  peak: 4194304  num: 1         avg: 4194304
  f5:                    2.106ms   (0%)    threads: 1.000  peak: 4194304  num: 1         avg: 4194304
  output_packed:         1.053ms   (0%)    threads: 1.000 
```

Performance profile after:

```
backprojection_post_fft
 total time: 3774.618408 ms  samples: 3529  runs: 1  time/run: 3774.618408 ms
 average threads used: 21.907055
 heap allocations: 12  peak heap usage: 3934259028 bytes
  norm_r0:               0.000ms   (0%)    threads: 0.000  peak: 1876     num: 1         avg: 1876
  sum:                   0.000ms   (0%)    threads: 0.000  stack: 4
  rr0:                   722.834ms (19%)   threads: 1.000  peak: 2950692864 num: 1       avg: -1344274432
  norm_rr0:              544.343ms (14%)   threads: 1.000  peak: 983564288 num: 1        avg: 983564288
  sum$1:                 83.078ms  (2%)    threads: 1.000  stack: 8
  dr_i:                  683.176ms (18%)   threads: 1.000  peak: 983564288 num: 1        avg: 983564288
  in_im:                 2.118ms   (0%)    threads: 1.000  peak: 3842048  num: 1         avg: 3842048
  f1:                    2.106ms   (0%)    threads: 1.000  peak: 3842048  num: 1         avg: 3842048
  Q_imag:                74.337ms  (1%)    threads: 56.963 peak: 491782144 num: 1        avg: 491782144
  Q_real:                59.366ms  (1%)    threads: 55.799 peak: 491782144 num: 1        avg: 491782144
  f2:                    338.627ms (8%)    threads: 1.000  peak: 983564288 num: 1        avg: 983564288
  f3:                    1218.125ms(32%)   threads: 60.272 peak: 4194304  num: 1         avg: 4194304
  f4:                    44.396ms  (1%)    threads: 1.000  peak: 4194304  num: 1         avg: 4194304
  f5:                    1.053ms   (0%)    threads: 1.000  peak: 4194304  num: 1         avg: 4194304
  output_packed:         1.053ms   (0%)    threads: 1.000
```
