### PR TITLE
Fix ComplexFunc naming.

### DIFF
--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -59,7 +59,7 @@ public:
         Expr npulses("npulses");
         npulses = phs.dim(2).extent();
         Func phs_func = phs;
-        ComplexFunc input(c, phs_func, "input");
+        ComplexFunc input(c, phs_func);
 
         // Create window
         Func win_x("win_x");
@@ -178,7 +178,7 @@ public:
         // inputs as functions
         Func in_func("in_func");
         in_func = in;
-        ComplexFunc input(c, in_func, "input");
+        ComplexFunc input(c, in_func);
 
         // some extents and related RDoms
         Expr N_fft = in.dim(1).extent();

--- a/complexfunc.h
+++ b/complexfunc.h
@@ -16,12 +16,11 @@ class ComplexExpr;
  */
 class ComplexFunc {
 public:
-    std::string name;
     Halide::Func inner;
     Halide::Var element;
 
-    ComplexFunc(Halide::Var &element, std::string name);
-    ComplexFunc(Halide::Var &element, Halide::Func &inner, std::string name);
+    ComplexFunc(Halide::Var &element, std::string name = "");
+    ComplexFunc(Halide::Var &element, Halide::Func &inner);
     ComplexExpr operator()(std::vector<Halide::Expr>);
     ComplexExpr operator()(Halide::Expr idx1);
     ComplexExpr operator()(Halide::Expr idx1, Halide::Expr idx2);
@@ -307,12 +306,16 @@ inline ComplexExpr select(const Halide::Var &element,
 // ComplexFunc methods
 
 ComplexFunc::ComplexFunc(Halide::Var &element, std::string name)
-    : name(name), element(element) {
-    inner(name + "_inner");
+    : element(element) {
+    if(name == "") {
+        inner = Halide::Func();
+    } else {
+        inner = Halide::Func(name);
+    }
 }
 
-ComplexFunc::ComplexFunc(Halide::Var &element, Halide::Func &inner, std::string name)
-    : name(name), inner(inner), element(element) {
+ComplexFunc::ComplexFunc(Halide::Var &element, Halide::Func &inner)
+    : inner(inner), element(element) {
 }
 
 ComplexExpr ComplexFunc::operator()(std::vector<Halide::Expr> idx) {

--- a/img_output.cpp
+++ b/img_output.cpp
@@ -14,9 +14,9 @@ public:
     void generate() {
         Var x{"x"}, y{"y"}, c{"c"};
 
-        Func img_func("img_func");
+        Func img_func("cimg");
         img_func = img;
-        ComplexFunc cimg(c, img_func, "input");
+        ComplexFunc cimg(c, img_func);
 
         RDom r(0, img.dim(1).extent(), 0, img.dim(2).extent(), "r");
         Func m("m");


### PR DESCRIPTION
In the direct constructor, calling the `inner` member's constructor explicitly was ineffective.  Create a new Func and assign the member to it, instead.

In the wrapper constructor, passing both a name and a func is silly, just pull the name from the passed Func instead.