### PR TITLE
Simplifications and scheduling

### DIFF
--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -197,14 +197,14 @@ public:
 
         // img: produces shape {nu*nv}
         img(x) = ComplexExpr(c, Expr(0.0), Expr(0.0));
-        img(x) += Q_hat(x, rnpulses) * exp(ComplexExpr(c, Expr(0.0), Expr(-1.0)) * k_c * dr_i(x, rnpulses));
+        img(x) += Q_hat(x, rnpulses) * expj(c, -k_c * dr_i(x, rnpulses));
 #if DEBUG_IMG
         out_img(c, x) = img.inner(c, x);
 #endif
 
         // finally...
         Expr fdr_i = norm_r0(npulses / 2) - norm_rr0(x, npulses / 2);
-        fimg(x) = img(x) * exp(ComplexExpr(c, Expr(0.0), Expr(1.0)) * k_c * fdr_i);
+        fimg(x) = img(x) * expj(c, k_c * fdr_i);
 #if DEBUG_FIMG
         out_fimg(c, x) = fimg.inner(c, x);
 #endif

--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -144,8 +144,10 @@ public:
         out_post_fft(c, x, y) = dft.inner(c, x, y);
 #endif
 
+        dft_out(x, y) = dft(x, y);
+
         // Q: produces shape {N_fft, npulses}
-        Q(x, y) = fftshift(dft, N_fft, npulses, x, y);
+        Q(x, y) = fftshift(dft_out, N_fft, npulses, x, y);
 #if DEBUG_Q
         out_Q(c, x, y) = Q.inner(c, x, y);
 #endif
@@ -239,6 +241,7 @@ public:
             phs_pad.inner.compute_root();
             fftsh.inner.compute_root();
             dft.inner.compute_root();
+            dft_out.inner.compute_inline();
             Q.inner.compute_root();
             norm_r0.compute_root();
             rr0.compute_root().parallel(z).vectorize(x, vectorsize);
@@ -267,6 +270,7 @@ public:
             phs_pad.inner.compute_root();
             fftsh.inner.compute_root();
             dft.inner.compute_root();
+            dft_out.inner.compute_inline();
             Q.inner.compute_root();
             norm_r0.compute_root();
             rr0.compute_root().parallel(z).vectorize(x, vectorsize);
@@ -295,6 +299,7 @@ private:
     ComplexFunc phs_pad{c, "phs_pad"};
     ComplexFunc fftsh{c, "fftshift"};
     ComplexFunc dft{c, "dft"};
+    ComplexFunc dft_out{c, "dft_out"};
     ComplexFunc Q{c, "Q"};
     Func norm_r0{"norm_r0"};
     Func rr0{"rr0"};


### PR DESCRIPTION
Split up the `schedule()` function into 3 parts: autoscheduler hints, GPU schedule, and CPU schedule.  This lets us fine-tune one without worrying about affecting the others.

Insert a Func between `dft` and `fftshift`.  This allows schedule syntax like this, which parallelizes calls to FFTW:
```
    fftsh.inner.compute_root();
    dft.inner.compute_inline();
    dft_out.inner.compute_root().parallel(y);
```

Simplify complex `exp()` calls to use `expj()`, to avoid the complex-complex multiply step.

Simplify Q_hat by computing both real and imaginary components the same way.  (They were already the same, I just removed the extra buffer and `select()` call in the middle.)

Work on CPU and GPU schedules.  See the profiles I posted in the comments for details.